### PR TITLE
STM32MP2-16: Pull meta-emcraft-torizon-st, branch "scarthgap" and meta-st-stm32, scarthgap release tag.

### DIFF
--- a/bsp/pinned-emcraft.xml
+++ b/bsp/pinned-emcraft.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<manifest>
+  <remote alias="repo" fetch="https://github.com/EmcraftSystems" name="emcraft"/>
+
+  <project name="meta-emcraft-torizon-st" path="layers/meta-emcraft-torizon-st" remote="emcraft" revision="scarthgap">
+    <linkfile dest="setup-environment" src="scripts/setup-environment"/>
+  </project>
+</manifest>

--- a/bsp/pinned-st.xml
+++ b/bsp/pinned-st.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<manifest>
+  <remote alias="repo" fetch="https://github.com/STMicroelectronics" name="stm"/>
+
+  <project name="meta-st-stm32mp" path="layers/meta-st-stm32mp" remote="stm" revision="refs/tags/openstlinux-6.6-yocto-scarthgap-mpu-v25.03.19"/>
+</manifest>

--- a/torizon/default.xml
+++ b/torizon/default.xml
@@ -4,6 +4,8 @@
   <include name="bsp/pinned-nxp.xml"/>
   <include name="bsp/pinned-ti.xml"/>
   <include name="bsp/pinned-tdx.xml"/>
+  <include name="bsp/pinned-emcraft.xml"/>
+  <include name="bsp/pinned-st.xml"/>
 
   <remote alias="repo" fetch="https://github.com/uptane" name="uptane"/>
   <remote alias="repo" fetch="https://github.com/toradex" name="toradex"/>
@@ -15,6 +17,5 @@
   <project name="meta-toradex-distro.git" path="layers/meta-toradex-distro" remote="tdx" revision="3ce5c481bafafd22130d58b01091d355fe95944f"/>
   <project name="meta-toradex-security" path="layers/meta-toradex-security" remote="toradex" revision="5ed9c3c402ca8ce92e95bacb7a3fe3e34231a8c6"/>
   <project name="meta-toradex-torizon" path="layers/meta-toradex-torizon" remote="torizon" revision="0011372d21bd8ae481e991972f63cd6e8b0f927d">
-    <linkfile dest="setup-environment" src="scripts/setup-environment"/>
   </project>
 </manifest>


### PR DESCRIPTION
- emcraft-st-scarthgap-7.x.y branch is for Emcraft port to STM32MP1x,2x boards.
- This is the "development" branch. Running "repo init -u https://github.com/EmcraftSystems/toradex-manifest.git -b emcraft-st-scarthgap-7.x.y" will create the build tree with the following layers: 
  - meta-toradex etc - from the current `scartghap-7.x.y` branch from Toradex git
  - meta-emcraft-torizon-st - from the current `scarthgap` branch
  - meta-st-stm32 - from the latest openstlinux-6.6-yocto-scarthgap-mpu-v25.03.19 release tag.